### PR TITLE
Update format information before computing penalty score

### DIFF
--- a/qrcode.c
+++ b/qrcode.c
@@ -1076,6 +1076,9 @@ bool QrCodeGenerate(qrcode_t* qrcode, uint8_t* buffer, uint8_t* scratchBuffer)
         {
             // XOR mask pattern
             QrCodeApplyMask(qrcode, maskPattern);
+            // Write format information
+            uint16_t formatInfo = QrCodeCalcFormatInfo(qrcode, qrcode->errorCorrectionLevel, maskPattern);
+            QrCodeDrawFormatInfo(qrcode, formatInfo);
 
             // Find penalty score for this mask pattern
             int penalty = QrCodeEvaluatePenalty(qrcode);


### PR DESCRIPTION
When I carefully compared the penalty scores between my implementation and yours, I saw some small discrepancies.  To get a 100% accurate score, the format information must be updated first, before computing the score.